### PR TITLE
fix: adding scikit-learn in requirements.txt and bumping gradio_client to version 1.3.0

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,7 @@
 gradio==4.43.0
-gradio_client==0.14.0
+gradio_client==1.3.0
 boto3==1.34.72
 openai==1.14.3
 python-dotenv==1.0.1
 ruff==0.3.4
+scikit-learn==1.5.2


### PR DESCRIPTION

*Issue :*
I had the following errors when trying the tool :
src/calibration.py", line 11, in <module>
    from sklearn.metrics import confusion_matrix
ModuleNotFoundError: No module named 'sklearn'

ERROR: Cannot install gradio==4.43.0 and gradio_client==0.14.0 because these package versions have conflicting dependencies.

*Description of changes:*
Updated requirements.txt accordingly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
